### PR TITLE
spring을 이용한 jdbc 통합 테스트 코드 추가

### DIFF
--- a/src/test/java/hello/hellospring/service/MemberServiceIntegrationTest.java
+++ b/src/test/java/hello/hellospring/service/MemberServiceIntegrationTest.java
@@ -1,0 +1,54 @@
+package hello.hellospring.service;
+
+import hello.hellospring.domain.Member;
+import hello.hellospring.repository.MemberRepository;
+import hello.hellospring.repository.MemoryMemberRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@Transactional
+class MemberServiceIntegrationTest {
+
+    @Autowired MemberService memberService;
+    @Autowired MemberRepository memberRepository;
+
+    @Test
+    void 회원가입() {
+        // given
+        Member member = new Member();
+        member.setName("spring");
+
+        // when
+        Long saveId = memberService.join(member);
+
+        // then
+        Member findMember = memberService.findOne(saveId).get();
+        assertThat(member.getName()).isEqualTo(findMember.getName());
+    }
+
+    @Test
+    public void 중복_회원_예외() {
+        // given
+        Member member1 = new Member();
+        member1.setName("spring1");
+
+        Member member2 = new Member();
+        member2.setName("spring1");
+
+        // when
+        memberService.join(member1);
+        IllegalStateException e = assertThrows(IllegalStateException.class, () -> memberService.join(member2));
+
+        // then
+        assertThat(e.getMessage()).isEqualTo("이미 존재하는 회원입니다.");
+    }
+
+}


### PR DESCRIPTION
@SpringBootTest : 스프링 컨테이너와 테스트를 함께 실행한다.

@Transactional : db는 commit을 해줘야 반영 되는데, 테스트 케이스에 이 애노테이션이 있으면 테스트 시작 전에 트랜잭션을 시작하고,
테스트 완료 후에 항상 롤백한다. 이렇게 하면 DB에 데이터가 남지 않으므로 다음 테스트에 영향을 주지 않는다.

스프링을 첨가한 테스트는 느리다고 잘 쪼개서 만든 단위 테스트가 더 좋은 테스트일 확률이 높다. 단위 테스트를 잘 만드는 연습이 필요하다.